### PR TITLE
Remove references to proxy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,9 +14,9 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch proxy",
+      "name": "Launch token-server",
       "runtimeExecutable": "npm",
-      "cwd": "${workspaceFolder}/proxy",
+      "cwd": "${workspaceFolder}/token-server",
       "runtimeArgs": [
         "run-script",
         "debug"

--- a/token-server/README.md
+++ b/token-server/README.md
@@ -19,7 +19,7 @@ Run,
 - Note the port the server starts on, that will be used when configuring the Viewer.
   - The PORT can be configured by setting the `PORT` in the `.env`
 
-## Setup the iTwin Viewer to use the proxy
+## Setup the iTwin Viewer to use the token server
 
 To configure the viewer to use the token server, make the following change to the `Viewer` component in [App.tsx](../react-viewer/src/App.tsx):
 


### PR DESCRIPTION
This repo should be renamed to something like:
    - "itwin-viewer-nonBentley-IdP" 
    - or "itwin-nonBentley-IdP"
    - or "itwin-platform-token-server" 
    - or "itwin-token-server-example"
    - or "itwin-token-server"
    - or "itwin-viewer-client-creds"

There is no "proxy" in this example. The iTwin Viewer component is used, but it's not necessary to demonstrate the point (although most users will be using the Viewer). 